### PR TITLE
fix(backtest): Enable FractionalBacktest with numpy workaround

### DIFF
--- a/docs/sprints/sprint-8-log.md
+++ b/docs/sprints/sprint-8-log.md
@@ -1,0 +1,8 @@
+# Sprint 8 Log — 2026-02-13
+
+**Goal**: Harden backtesting robustness: fractional trading, out-of-sample validation, and overfitting detection
+**Planned**: 6 issues
+
+## Huddles
+
+[Huddles will be appended here after each issue completes]


### PR DESCRIPTION
fixes #29

## What was broken
BTC-USD backtests at >$100k prices caused 'insufficient margin' warnings because the backtesting engine couldn't handle fractional shares.

## Root cause
`backtesting.Backtest` doesn't support fractional trading. `FractionalBacktest` exists but has a numpy bug (`ValueError: output array is read-only`) when dividing overlay indicators.

## Fix
- Subclass `FractionalBacktest` with a custom `run()` that calls `setflags(write=True)` on overlay indicators before in-place division
- Import alias so all 4 Backtest instantiation points automatically use fractional trading

## Verification
- All 6 strategies produce trades on BTC-USD without warnings
- 58 existing tests pass
- Non-crypto symbols (SPY) continue to work