### PR TITLE
feat(backtest): add train/test split to optimize command

### DIFF
--- a/docs/sprints/sprint-8-log.md
+++ b/docs/sprints/sprint-8-log.md
@@ -5,4 +5,12 @@
 
 ## Huddles
 
-[Huddles will be appended here after each issue completes]
+### Huddle — After Issue #29
+
+**Completed**: #29 — FractionalBacktest enabled, all 6 strategies work on BTC-USD without margin warnings (PR #36)
+**Sprint progress**: 1/6 issues done
+**Key learning**: numpy read-only array flags need explicit unlock for in-place operations on backtesting.py indicators
+
+**Plan check**: No changes needed. CI has pre-existing config issue (externally managed Python) — not related to our changes.
+
+**Next up**: #34 — Train/test split for optimize command


### PR DESCRIPTION
fixes #34

## Changes
- `optimize_strategy()` now accepts `split` param (default 0.7 = 70/30 train/test)
- Reports both in-sample (IS) and out-of-sample (OOS) metrics side by side
- CLI `--split` option: `--split 0.7` (default), `--split 0.8`, `--split 1.0` (legacy)
- Results sorted by OOS Sharpe ratio (not IS)
- Helper `_extract_metrics()` reduces duplication

## Acceptance Criteria
- [x] Output shows separate 'In-Sample' and 'Out-of-Sample' columns
- [x] Default split is 70/30
- [x] `--split 0.8` allows custom split ratio
- [x] `--split 1.0` preserves current behavior (no split)
- [x] Results sorted by out-of-sample Sharpe

## Tests (4 new, 62 total)
- `test_optimize_split_default_70_30` — IS/OOS metrics present, OOS Sharpe sorted
- `test_optimize_split_custom_80_20` — custom ratio works
- `test_optimize_split_1_preserves_legacy` — no IS metrics in legacy mode
- `test_optimize_invalid_split_raises` — validates split bounds