### PR TITLE
feat(backtest): add rolling and expanding window modes to walk-forward

### DIFF
--- a/docs/sprints/sprint-8-log.md
+++ b/docs/sprints/sprint-8-log.md
@@ -14,3 +14,13 @@
 **Plan check**: No changes needed. CI has pre-existing config issue (externally managed Python) — not related to our changes.
 
 **Next up**: #34 — Train/test split for optimize command
+
+### Huddle — After Issue #34
+
+**Completed**: #34 — Train/test split for optimize added, IS/OOS metrics, --split CLI param (PR #37)
+**Sprint progress**: 2/6 issues done
+**Key learning**: _extract_metrics() helper reduces duplication; #35 dependency unblocked
+
+**Plan check**: No changes. Moving to #31 (rolling window) next — unblocks #32 (expanding window).
+
+**Next up**: #31 — Rolling window walk-forward


### PR DESCRIPTION
fixes #31
fixes #32

## Changes
- Refactored `walk_forward()` to support 3 windowing modes via `mode` parameter
- **sequential** (default): existing non-overlapping N-split behavior  
- **rolling**: fixed-size train window slides forward by `step` bars
- **expanding**: train grows from data start, test is next `step` bars
- Extracted shared helpers: `_optimize_on_data()`, `_evaluate_fold()`, fold generators
- CLI: `--mode rolling --train-bars 500 --step 100`

## Acceptance Criteria (#31)
- [x] `walk-forward bollinger-bands --mode rolling --train-bars 500 --step 100` produces overlapping folds
- [x] Each fold trains on exactly train_bars bars
- [x] Test window is the next step bars after train window
- [x] No data leakage (train strictly before test)
- [x] Existing sequential mode unchanged

## Acceptance Criteria (#32)
- [x] Expanding mode: train grows from start
- [x] CLI: `--mode expanding --train-bars 200 --step 100`

## Tests (4 new, 65 total)
- Sequential default, rolling mode, expanding mode, invalid mode validation