### PR TITLE
feat(backtest): add parameter stability report to walk-forward

### DIFF
--- a/src/meta_strategy/cli.py
+++ b/src/meta_strategy/cli.py
@@ -324,6 +324,16 @@ def walk_forward_cmd(
 
     typer.echo(f"📊 Average out-of-sample: Return {result['avg_test_return_pct']:.2f}%, Sharpe {result['avg_test_sharpe']:.2f}")
 
+    stability = result.get("param_stability", {})
+    if stability and stability.get("params_per_fold"):
+        typer.echo(f"\n📋 Parameter Stability: {stability['score_pct']:.0f}% stable")
+        if stability["changes"]:
+            typer.echo("   ⚠️  Unstable parameters (>50% change between consecutive folds):")
+            for c in stability["changes"]:
+                typer.echo(f"      {c['param']}: fold {c['fold_from']}→{c['fold_to']}: {c['prev']} → {c['curr']} ({c['pct_change']:.0f}% change)")
+        else:
+            typer.echo("   ✅ All parameters consistent across folds")
+
 
 @app.command()
 def report(


### PR DESCRIPTION
fixes #33

## Changes
- `param_stability_report()` analyzes best params across walk-forward folds
- Flags when any param changes >50% between consecutive folds
- Returns stability score (% consistent) and detailed change list
- Walk-forward output now includes 📋 Parameter Stability section

## Acceptance Criteria
- [x] Walk-forward output includes parameter stability section
- [x] Shows best params per fold side-by-side
- [x] Flags >50% parameter changes across consecutive folds
- [x] Summary includes stability score

## Tests (4 new, 73 total)