### PR TITLE
feat: normalize B&H baseline across strategies

### DIFF
--- a/src/meta_strategy/cli.py
+++ b/src/meta_strategy/cli.py
@@ -132,7 +132,7 @@ def backtest(
     typer.echo(f"📊 Running {strategy_name} on {symbol} ({start} → {end or 'today'})...")
     result = run_backtest(strategy_name, symbol=symbol, start=start, end=end, cash=cash, commission=commission)
 
-    typer.echo(f"\n{'='*60}")
+    typer.echo(f"\n{'=' * 60}")
     typer.echo(f"  Strategy:        {result['strategy']}")
     typer.echo(f"  Symbol:          {result['symbol']}")
     typer.echo(f"  Period:          {result['period']}")
@@ -143,7 +143,7 @@ def backtest(
     typer.echo(f"  Max Drawdown:    {result['max_drawdown_pct']:>10.2f}%")
     typer.echo(f"  Sharpe Ratio:    {result['sharpe_ratio']:>10.2f}")
     typer.echo(f"  Final Equity:    ${result['final_equity']:>10.2f}")
-    typer.echo(f"{'='*60}")
+    typer.echo(f"{'=' * 60}")
 
 
 @app.command(name="backtest-all")
@@ -160,6 +160,13 @@ def backtest_all(
 
     typer.echo(f"📊 Running all strategies on {symbol} ({start} → {end or 'today'})...\n")
     results = run_all_backtests(symbol=symbol, start=start, end=end, cash=cash, commission=commission)
+
+    if results:
+        r0 = results[0]
+        typer.echo(
+            f"📐 B&H normalized: {r0['warmup_bars_trimmed']} warmup bars trimmed, "
+            f"effective start: {r0['effective_start']}\n"
+        )
 
     # Print comparison table
     header = (
@@ -292,8 +299,7 @@ def optimize(
             typer.echo(line)
     else:
         header = (
-            f"{'Rank':<6} {'Params':<40} {'Return%':>10} "
-            f"{'Sharpe':>8} {'Trades':>8} {'MaxDD%':>10} {'WinRate%':>10}"
+            f"{'Rank':<6} {'Params':<40} {'Return%':>10} {'Sharpe':>8} {'Trades':>8} {'MaxDD%':>10} {'WinRate%':>10}"
         )
         sep = "-" * 92
         typer.echo(header)
@@ -316,6 +322,7 @@ def optimize(
             )
             typer.echo(best_line)
             from .backtest import check_overfitting
+
             warning = check_overfitting(best)
             if warning:
                 ratio_str = f"{warning['ratio']:.1f}×" if warning["ratio"] != float("inf") else "∞×"
@@ -357,8 +364,15 @@ def walk_forward_cmd(
     typer.echo(f"🔄 Walk-forward analysis: {strategy_name} on {symbol} ({label})...\n")
 
     result = walk_forward(
-        strategy_name, symbol=symbol, start=start, n_splits=splits,
-        train_pct=train_pct, cash=cash, mode=mode, train_bars=train_bars, step=step,
+        strategy_name,
+        symbol=symbol,
+        start=start,
+        n_splits=splits,
+        train_pct=train_pct,
+        cash=cash,
+        mode=mode,
+        train_bars=train_bars,
+        step=step,
     )
 
     for f in result["folds"]:
@@ -372,8 +386,10 @@ def walk_forward_cmd(
         typer.echo(fold_line)
         typer.echo("")
 
-    typer.echo(f"\n📊 Average out-of-sample: Return {result['avg_test_return_pct']:.2f}%, "
-               f"Sharpe {result['avg_test_sharpe']:.2f}")
+    typer.echo(
+        f"\n📊 Average out-of-sample: Return {result['avg_test_return_pct']:.2f}%, "
+        f"Sharpe {result['avg_test_sharpe']:.2f}"
+    )
 
     stability = result.get("param_stability", {})
     if stability and stability.get("params_per_fold"):

--- a/src/meta_strategy/reports.py
+++ b/src/meta_strategy/reports.py
@@ -128,12 +128,10 @@ def _svg_equity_chart(equity_curves: dict[str, pd.Series], width: int = 800, hei
             points.append(f"{x:.1f},{y:.1f}")
 
         lines.append(
-            f'<polyline points="{" ".join(points)}" fill="none" stroke="{color}" '
-            f'stroke-width="1.5" opacity="0.9"/>'
+            f'<polyline points="{" ".join(points)}" fill="none" stroke="{color}" stroke-width="1.5" opacity="0.9"/>'
         )
         legend_items.append(
-            f'<span class="legend-item"><span class="legend-dot" '
-            f'style="background:{color}"></span>{name}</span>'
+            f'<span class="legend-item"><span class="legend-dot" style="background:{color}"></span>{name}</span>'
         )
 
     # Y-axis labels
@@ -148,7 +146,7 @@ def _svg_equity_chart(equity_curves: dict[str, pd.Series], width: int = 800, hei
 
     svg = f"""<div class="chart">
 <svg viewBox="0 0 {width} {height}">
-  <rect x="{margin['left']}" y="{margin['top']}" width="{plot_w}" height="{plot_h}" fill="none" stroke="#30363d"/>
+  <rect x="{margin["left"]}" y="{margin["top"]}" width="{plot_w}" height="{plot_h}" fill="none" stroke="#30363d"/>
   {y_labels}
   {"".join(lines)}
 </svg>
@@ -171,17 +169,17 @@ def generate_html_report(
     # Build content
     ret_class = "positive" if result["return_pct"] > 0 else "negative"
     content = f"""
-<h2>{result['strategy']} on {result['symbol']}</h2>
+<h2>{result["strategy"]} on {result["symbol"]}</h2>
 <table>
   <tr><th>Metric</th><th>Value</th></tr>
-  <tr><td>Period</td><td>{result['period']}</td></tr>
-  <tr><td>Return</td><td class="{ret_class}">{result['return_pct']:.2f}%</td></tr>
-  <tr><td>Buy &amp; Hold</td><td>{result['buy_hold_return_pct']:.2f}%</td></tr>
-  <tr><td>Win Rate</td><td>{result['win_rate_pct']:.2f}%</td></tr>
-  <tr><td># Trades</td><td>{result['num_trades']}</td></tr>
-  <tr><td>Max Drawdown</td><td class="negative">{result['max_drawdown_pct']:.2f}%</td></tr>
-  <tr><td>Sharpe Ratio</td><td>{result['sharpe_ratio']:.2f}</td></tr>
-  <tr><td>Final Equity</td><td>${result['final_equity']:,.2f}</td></tr>
+  <tr><td>Period</td><td>{result["period"]}</td></tr>
+  <tr><td>Return</td><td class="{ret_class}">{result["return_pct"]:.2f}%</td></tr>
+  <tr><td>Buy &amp; Hold</td><td>{result["buy_hold_return_pct"]:.2f}%</td></tr>
+  <tr><td>Win Rate</td><td>{result["win_rate_pct"]:.2f}%</td></tr>
+  <tr><td># Trades</td><td>{result["num_trades"]}</td></tr>
+  <tr><td>Max Drawdown</td><td class="negative">{result["max_drawdown_pct"]:.2f}%</td></tr>
+  <tr><td>Sharpe Ratio</td><td>{result["sharpe_ratio"]:.2f}</td></tr>
+  <tr><td>Final Equity</td><td>${result["final_equity"]:,.2f}</td></tr>
 </table>
 
 <h2>Equity Curve</h2>
@@ -202,6 +200,7 @@ def generate_html_report(
 
 
 # === Comparison Dashboard (#17) ===
+
 
 def generate_dashboard(
     symbol: str = "BTC-USD",
@@ -224,14 +223,14 @@ def generate_dashboard(
     for _name, (r, _) in results_and_equity.items():
         ret_class = "positive" if r["return_pct"] > 0 else "negative"
         rows += f"""<tr>
-  <td>{r['strategy']}</td>
-  <td class="{ret_class}">{r['return_pct']:.2f}%</td>
-  <td>{r['buy_hold_return_pct']:.2f}%</td>
-  <td>{r['win_rate_pct']:.2f}%</td>
-  <td>{r['num_trades']}</td>
-  <td class="negative">{r['max_drawdown_pct']:.2f}%</td>
-  <td>{r['sharpe_ratio']:.2f}</td>
-  <td>${r['final_equity']:,.2f}</td>
+  <td>{r["strategy"]}</td>
+  <td class="{ret_class}">{r["return_pct"]:.2f}%</td>
+  <td>{r["buy_hold_return_pct"]:.2f}%</td>
+  <td>{r["win_rate_pct"]:.2f}%</td>
+  <td>{r["num_trades"]}</td>
+  <td class="negative">{r["max_drawdown_pct"]:.2f}%</td>
+  <td>{r["sharpe_ratio"]:.2f}</td>
+  <td>${r["final_equity"]:,.2f}</td>
 </tr>"""
 
     # Equity curves
@@ -240,7 +239,7 @@ def generate_dashboard(
     if results_and_equity:
         valid = [(n, r) for n, (r, _) in results_and_equity.items() if r["num_trades"] > 0]
         best = max(valid, key=lambda x: x[1]["sharpe_ratio"]) if valid else None
-        best_line = f'<p>🏆 <strong>Best Sharpe:</strong> {best[0]} ({best[1]["sharpe_ratio"]:.2f})</p>' if best else ""
+        best_line = f"<p>🏆 <strong>Best Sharpe:</strong> {best[0]} ({best[1]['sharpe_ratio']:.2f})</p>" if best else ""
     else:
         best_line = ""
 
@@ -271,6 +270,7 @@ def generate_dashboard(
 
 
 # === Export (#18) ===
+
 
 def export_results_json(results: list[dict], output_path: str) -> None:
     """Export backtest results to JSON."""

--- a/src/meta_strategy/risk.py
+++ b/src/meta_strategy/risk.py
@@ -14,6 +14,7 @@ from .backtest import STRATEGIES, fetch_data
 
 # === Extended Risk Metrics (#24) ===
 
+
 def compute_risk_metrics(equity_series: pd.Series, risk_free_rate: float = 0.0) -> dict:
     """Compute extended risk metrics from an equity curve.
 
@@ -101,6 +102,7 @@ def _empty_metrics() -> dict:
 
 
 # === Monte Carlo Simulation (#23) ===
+
 
 def monte_carlo(
     strategy_name: str,

--- a/src/meta_strategy/validator.py
+++ b/src/meta_strategy/validator.py
@@ -52,26 +52,30 @@ def validate_pine_script(content: str) -> list[ValidationWarning]:
 def _check_lookahead(line_num: int, line: str) -> list[ValidationWarning]:
     """Detect lookahead_on usage — this is cheating in backtests."""
     if "lookahead_on" in line or "lookahead=barmerge.lookahead_on" in line:
-        return [ValidationWarning(
-            line_number=line_num,
-            severity=Severity.CRITICAL,
-            rule="no-lookahead",
-            message="lookahead_on detected — this produces false backtest results",
-            suggestion="Remove lookahead_on or use barmerge.lookahead_off",
-        )]
+        return [
+            ValidationWarning(
+                line_number=line_num,
+                severity=Severity.CRITICAL,
+                rule="no-lookahead",
+                message="lookahead_on detected — this produces false backtest results",
+                suggestion="Remove lookahead_on or use barmerge.lookahead_off",
+            )
+        ]
     return []
 
 
 def _check_missing_gap_fill(line_num: int, line: str) -> list[ValidationWarning]:
     """Detect request.security() calls without gap filling."""
     if "request.security(" in line and "gaps" not in line and "fillgaps" not in line.lower():
-        return [ValidationWarning(
-            line_number=line_num,
-            severity=Severity.WARNING,
-            rule="fill-gaps",
-            message="request.security() without gap filling — may cause staircase lines",
-            suggestion="Add gaps=barmerge.gaps_off or fillgaps=true",
-        )]
+        return [
+            ValidationWarning(
+                line_number=line_num,
+                severity=Severity.WARNING,
+                rule="fill-gaps",
+                message="request.security() without gap filling — may cause staircase lines",
+                suggestion="Add gaps=barmerge.gaps_off or fillgaps=true",
+            )
+        ]
     return []
 
 
@@ -84,23 +88,30 @@ def _check_invalid_variables(line_num: int, line: str) -> list[ValidationWarning
         return []
     # Only flag when used as standalone variables, not inside strategy() params
     if "strategy.commission.percent" in line and "commission_type" not in line:
-        warnings.append(ValidationWarning(
-            line_number=line_num,
-            severity=Severity.CRITICAL,
-            rule="invalid-variable",
-            message="strategy.commission.percent used as variable — does not exist in Pine Script",
-            suggestion="Set commission in the strategy() function: commission_type=strategy.commission.percent",
-        ))
-    if ("strategy.slippage" in line and "slippage" not in line.split("strategy.slippage")[0]
-            and not re.search(r'strategy\s*\(.*strategy\.slippage', line)
-            and (stripped.startswith("strategy.slippage") or "= strategy.slippage" in line)):
-        warnings.append(ValidationWarning(
-            line_number=line_num,
-            severity=Severity.CRITICAL,
-            rule="invalid-variable",
-            message="strategy.slippage used as variable — does not exist in Pine Script",
-            suggestion="Set slippage in the strategy() function: slippage=N",
-        ))
+        warnings.append(
+            ValidationWarning(
+                line_number=line_num,
+                severity=Severity.CRITICAL,
+                rule="invalid-variable",
+                message="strategy.commission.percent used as variable — does not exist in Pine Script",
+                suggestion="Set commission in the strategy() function: commission_type=strategy.commission.percent",
+            )
+        )
+    if (
+        "strategy.slippage" in line
+        and "slippage" not in line.split("strategy.slippage")[0]
+        and not re.search(r"strategy\s*\(.*strategy\.slippage", line)
+        and (stripped.startswith("strategy.slippage") or "= strategy.slippage" in line)
+    ):
+        warnings.append(
+            ValidationWarning(
+                line_number=line_num,
+                severity=Severity.CRITICAL,
+                rule="invalid-variable",
+                message="strategy.slippage used as variable — does not exist in Pine Script",
+                suggestion="Set slippage in the strategy() function: slippage=N",
+            )
+        )
     return warnings
 
 
@@ -110,13 +121,15 @@ def _check_strategy_name_prefix(line_num: int, line: str) -> list[ValidationWarn
     if match:
         name = match.group(1)
         if not name.startswith("AI - "):
-            return [ValidationWarning(
-                line_number=line_num,
-                severity=Severity.INFO,
-                rule="name-prefix",
-                message=f'Strategy name "{name}" does not start with "AI - "',
-                suggestion=f'Rename to "AI - {name}"',
-            )]
+            return [
+                ValidationWarning(
+                    line_number=line_num,
+                    severity=Severity.INFO,
+                    rule="name-prefix",
+                    message=f'Strategy name "{name}" does not start with "AI - "',
+                    suggestion=f'Rename to "AI - {name}"',
+                )
+            ]
     return []
 
 
@@ -147,13 +160,15 @@ def _check_line_breaks_in_calls(lines: list[str]) -> list[ValidationWarning]:
                     continue
                 # If next line is indented and doesn't start a new statement, likely a broken call
                 if lines[j].startswith(" ") or lines[j].startswith("\t"):
-                    warnings.append(ValidationWarning(
-                        line_number=i + 1,
-                        severity=Severity.WARNING,
-                        rule="no-line-breaks",
-                        message="Possible line break in function call/expression — Pine Script may not support this",
-                        suggestion="Put the entire expression on a single line",
-                    ))
+                    warnings.append(
+                        ValidationWarning(
+                            line_number=i + 1,
+                            severity=Severity.WARNING,
+                            rule="no-line-breaks",
+                            message="Possible line break in call/expression — Pine Script may not support this",
+                            suggestion="Put the entire expression on a single line",
+                        )
+                    )
                 break
 
     return warnings


### PR DESCRIPTION
Fixes #45

**Problem**: `backtest-all` showed different Buy & Hold returns per strategy because `backtesting.py` calculates B&H from each strategy's first valid indicator bar (e.g., RSI with 200-SMA starts 199 bars later than SuperTrend).

**Solution**: 
- `detect_warmup()` calculates each strategy's indicator warmup by running indicator functions and finding first non-NaN bar
- `run_all_backtests()` finds max warmup across all strategies, then overrides B&H with a normalized value calculated from the max warmup bar
- CLI shows `📐 B&H normalized: N warmup bars trimmed, effective start: YYYY-MM-DD`

**Individual `backtest` command unchanged** — only `backtest-all` normalizes.

5 new tests (73 → 78 total), lint clean.